### PR TITLE
MB validation

### DIFF
--- a/tests/rules.json
+++ b/tests/rules.json
@@ -42,7 +42,7 @@
         "errorMessage" : "Missing 'Required Hardware and Software' section."
     },
     {
-        "regex" : "\\d\\s?[Mm]ega\\s[Bb]yte|\\d\\s?Mega\\s?[Bb]yte|\\d\\s?mb[\\s\\.]|(?i)mbytes",
+        "regex" : "\\d\\s?[Mm]ega\\s[Bb]yte|\\d\\s?Mega\\s?[Bb]yte|\\d\\s?mb[\\s\\.]|[Mm][Bb]ytes",
         "shouldMatch" : false,
         "format" : "markdown",
         "errorMessage" : "Megabytes should be either written as 'megabytes' or abbreviated as 'MB'"

--- a/tests/rules.json
+++ b/tests/rules.json
@@ -40,5 +40,11 @@
         "shouldMatch" : true,
         "format" : "markdown",
         "errorMessage" : "Missing 'Required Hardware and Software' section."
+    },
+    {
+        "regex" : "\\d\\s?[Mm]ega\\s[Bb]yte|\\d\\s?Mega\\s?[Bb]yte|\\d\\s?mb[\\s\\.]|(?i)mbytes",
+        "shouldMatch" : false,
+        "format" : "markdown",
+        "errorMessage" : "Megabytes should be either written as 'megabytes' or abbreviated as 'MB'"
     }
 ]


### PR DESCRIPTION
This PR adds validation for consistent 'megabytes' spelling.
Test is here: https://regex101.com/r/ed6vPh/1

![image](https://user-images.githubusercontent.com/1326220/108394524-14932780-7215-11eb-98e0-559e5566e658.png)
